### PR TITLE
Removed not existing field from MediaVideos struct

### DIFF
--- a/instagram/media.go
+++ b/instagram/media.go
@@ -86,7 +86,6 @@ type MediaImage struct {
 // MediaVideos represents MediaVideo with various resolutions.
 type MediaVideos struct {
 	LowResolution      *MediaVideo `json:"low_resolution,omitempty"`
-	Thumbnail          *MediaVideo `json:"thumbnail,omitempty"`
 	StandardResolution *MediaVideo `json:"standard_resolution,omitempty"`
 }
 


### PR DESCRIPTION
http://instagram.com/developer/endpoints/users/
as we can see here, Video has only `low_resolution` and `standard_resolution` fields
