### PR TITLE
Add support for the /media/shortcode endpoint

### DIFF
--- a/instagram/media.go
+++ b/instagram/media.go
@@ -124,6 +124,22 @@ func (s *MediaService) Get(mediaId string) (*Media, error) {
 	return media, err
 }
 
+// Get information about a media object using its shortcode (found in the URL).
+// This endpoint returns the same response as GET /media/media-id.
+//
+// Instagram API docs: https://instagram.com/developer/endpoints/media/#get_media_by_shortcode
+func (s *MediaService) Shortcode(sc string) (*Media, error) {
+	u := fmt.Sprintf("media/shortcode/%v", sc)
+	req, err := s.client.NewRequest("GET", u, "")
+	if err != nil {
+		return nil, err
+	}
+
+	media := new(Media)
+	_, err = s.client.Do(req, media)
+	return media, err
+}
+
 // Search return search results for media in a given area.
 //
 // http://instagram.com/developer/endpoints/media/#get_media_search

--- a/instagram/media_test.go
+++ b/instagram/media_test.go
@@ -32,6 +32,26 @@ func TestMediaService_Get(t *testing.T) {
 	}
 }
 
+func TestMediaService_Shortcode(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/media/shortcode/9ApM9cDJx6", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"data":{"id": "1099059519587916922_259220806"}}`)
+	})
+
+	media, err := client.Media.Shortcode("9ApM9cDJx6")
+	if err != nil {
+		t.Errorf("Media.Shortcode returned error: %v", err)
+	}
+
+	want := &Media{ID: "1099059519587916922_259220806"}
+	if !reflect.DeepEqual(media, want) {
+		t.Errorf("Media.Get returned %+v, want %+v", media, want)
+	}
+}
+
 func TestMediaService_Search(t *testing.T) {
 	setup()
 	defer teardown()

--- a/instagram/media_test.go
+++ b/instagram/media_test.go
@@ -48,7 +48,7 @@ func TestMediaService_Shortcode(t *testing.T) {
 
 	want := &Media{ID: "1099059519587916922_259220806"}
 	if !reflect.DeepEqual(media, want) {
-		t.Errorf("Media.Get returned %+v, want %+v", media, want)
+		t.Errorf("Media.Shortcode returned %+v, want %+v", media, want)
 	}
 }
 


### PR DESCRIPTION
This commit will add a new `MediaService` method to fetch a media object using its URL shortcode.

It works pretty much the same way `Media.Get` does, except it's using the shortcode as an argument rather than the media ID.

For more information: https://instagram.com/developer/endpoints/media/#get_media_by_shortcode
