### PR TITLE
add count param to media search querystring

### DIFF
--- a/instagram/media.go
+++ b/instagram/media.go
@@ -146,6 +146,9 @@ func (s *MediaService) Search(opt *Parameters) ([]Media, *ResponsePagination, er
 		if opt.Distance != 0 {
 			params.Add("distance", strconv.FormatFloat(opt.Distance, 'f', 7, 64))
 		}
+		if opt.Count != 0 {
+			params.Add("count", strconv.FormatUint(opt.Count, 10))
+		}
 		u += "?" + params.Encode()
 	}
 

--- a/instagram/media_test.go
+++ b/instagram/media_test.go
@@ -44,6 +44,7 @@ func TestMediaService_Search(t *testing.T) {
 			"max_timestamp": "1",
 			"min_timestamp": "1",
 			"distance":      "1000.0000000",
+			"count":         "100",
 		})
 		fmt.Fprint(w, `{"data": [{"id":"1"}]}`)
 	})
@@ -54,6 +55,7 @@ func TestMediaService_Search(t *testing.T) {
 		MinTimestamp: 1,
 		MaxTimestamp: 1,
 		Distance:     1000,
+		Count:        100,
 	}
 	media, _, err := client.Media.Search(opt)
 	if err != nil {


### PR DESCRIPTION
media search endpoint return only 20 items without `count` parameter